### PR TITLE
Add preserveAspectRatioTag prop and strip aspectRatio by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ npm test
 Thanks to:
 - [ivantumanov](https://github.com/ivantumanov) 
 - [ohtake](https://github.com/ohtake)
+- [eiwi1101](https://github.com/eiwi1101)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Dean Merchant <deanmerchant@gmail.com> (http://github.com/dean177)",
   "contributors": [
     "ivantumanov",
-    "ohtake"
+    "ohtake",
+    "eiwi1101"
   ],
   "license": "ISC",
   "bugs": {

--- a/src/demo/demo.js
+++ b/src/demo/demo.js
@@ -52,7 +52,9 @@ class Demo extends React.Component {
         <h2>Usage</h2>
         <p>
           Every element contained within <code>{'<JustifiedLayout>'}</code> must have either
-          height and width 'style' props, or have an 'aspectRatio' prop
+          height and width 'style' props, or have an 'aspectRatio' prop. If the 'aspectRatio'
+          prop is present, it will be removed before rendering. This prop can be preserved
+          by setting the 'preserveAspectRatioTag' prop to true.
         </p>
         <pre>
           <code>{`

--- a/src/react-justified-layout.js
+++ b/src/react-justified-layout.js
@@ -51,7 +51,7 @@ const JustPropTypes = {
     })
   ]),
   containerWidth: PropTypes.number,
-  forceAspectRation: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
+  forceAspectRatio: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
   fullWidthBreakoutRowCadence: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.number
@@ -60,20 +60,22 @@ const JustPropTypes = {
   showWidows: PropTypes.bool,
   targetRowHeight: PropTypes.number,
   targetRowHeightTolerance: PropTypes.number,
-  widowLayoutStyle: PropTypes.string
+  widowLayoutStyle: PropTypes.string,
+  preserveAspectRatioTag: PropTypes.bool
 };
 
 const JustDefaultProps = {
   boxSpacing: 10,
   containerPadding: 10,
   containerWidth: 1060,
-  forceAspectRation: false,
+  forceAspectRatio: false,
   fullWidthBreakoutRowCadence: false,
   maxNumRows: Number.POSITIVE_INFINITY,
   showWidows: true,
   targetRowHeight: 320,
   targetRowHeightTolerance: 0.25,
-  widowLayoutStyle: 'left'
+  widowLayoutStyle: 'left',
+  preserveAspectRatioTag: false
 };
 
 class JustifiedLayout extends React.Component {
@@ -82,7 +84,7 @@ class JustifiedLayout extends React.Component {
   static defaultProps: JustDefaultProps;
 
   render() {
-    const { children, style, ...config } = this.props;
+    const { children, style, preserveAspectRatioTag, ...config } = this.props;
     const childDims = React.Children
       .map(children, extractDimension)
       .map(normalizeDimension);
@@ -94,10 +96,17 @@ class JustifiedLayout extends React.Component {
       <div style={{ ...Style, ...style, height: containerHeight, width: this.props.containerWidth }}>
         {map(elementLayout, ([element, layout]) => {
           const { height, left, top, width } = layout;
+
+          // Remove aspectRatio tag when rendering to prevent React errors:
+          let elementProps = element.props;
+          if (!preserveAspectRatioTag) {
+            delete elementProps.aspectRatio;
+          }
+
           return React.cloneElement(element, {
-            ...element.props,
+            ...elementProps,
             style: {
-              ...element.props.style,
+              ...elementProps.style,
               position: 'absolute',
               height, left, top, width
             }

--- a/src/react-justified-layout.js
+++ b/src/react-justified-layout.js
@@ -100,7 +100,8 @@ class JustifiedLayout extends React.Component {
           // Remove aspectRatio tag when rendering to prevent React errors:
           let elementProps = element.props;
           if (!preserveAspectRatioTag) {
-            delete elementProps.aspectRatio;
+            let { aspectRatio, ...rest } = element.props;
+            elementProps = rest;
           }
 
           return React.cloneElement(element, {


### PR DESCRIPTION
An (extremely delayed) followup to https://github.com/Dean177/react-justified-layout/issues/3